### PR TITLE
fix: Correct loading state assignment in ConfigLoader

### DIFF
--- a/src/common/ConfigLoader.tsx
+++ b/src/common/ConfigLoader.tsx
@@ -51,8 +51,8 @@ export const ConfigLoader: React.FC<{ children: ReactNode }> = ({ children }) =>
                             auth: authResponse[ 0 ]
                         }
                     });
-                    authConfigLoadedRef.current = true;
                 }
+                authConfigLoadedRef.current = true;
             } catch (error) {
                 console.error('Error loading auth config:', error);
             } finally {


### PR DESCRIPTION
- Moved the assignment of authConfigLoadedRef.current to ensure it is set after the try-catch block, improving the reliability of the loading state handling.