### PR TITLE
fix(query): improve react-query cache invalidation for entities

### DIFF
--- a/src/core/query/useEntityMutation.ts
+++ b/src/core/query/useEntityMutation.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useApi, type IApiConfig } from '../context/ApiContext';
 import { queryKeys } from './queryKeys';
 import { queryClient } from './QueryProvider';
+import { deriveEntityName } from '../utils';
 
 export interface UseEntityMutationOptions {
   /** Entity name — used to invalidate related caches on success */
@@ -59,14 +60,14 @@ export function useEntityMutation({ entityName, relatedEntities = [], onInvalida
     if (onInvalidate) {
       await onInvalidate();
     }
-  }, [queryClient, entityName, relatedEntities, onInvalidate]);
+  }, [ queryClient, entityName, relatedEntities, onInvalidate ]);
 
   /**
    * Invalidate only list queries (lighter-weight, for when detail data is unchanged).
    */
   const invalidateLists = useCallback(
     () => queryClient.invalidateQueries({ queryKey: queryKeys.entity(entityName).lists() }),
-    [queryClient, entityName]
+    [ queryClient, entityName ]
   );
 
   /**
@@ -74,7 +75,7 @@ export function useEntityMutation({ entityName, relatedEntities = [], onInvalida
    */
   const invalidateDetails = useCallback(
     () => queryClient.invalidateQueries({ queryKey: queryKeys.entity(entityName).details() }),
-    [queryClient, entityName]
+    [ queryClient, entityName ]
   );
 
   /**
@@ -82,7 +83,7 @@ export function useEntityMutation({ entityName, relatedEntities = [], onInvalida
    */
   const invalidateFieldOptions = useCallback(
     () => queryClient.invalidateQueries({ queryKey: queryKeys.entity(entityName).allFieldOptions() }),
-    [queryClient, entityName]
+    [ queryClient, entityName ]
   );
 
   return {
@@ -102,6 +103,7 @@ export function useEntityMutation({ entityName, relatedEntities = [], onInvalida
  * Uses the singleton queryClient, so no hook context is required.
  */
 export function invalidateEntityCacheByName(entityName: string): Promise<void> {
+  console.log('[invalidateEntityCacheByName] invalidating queryKey:', queryKeys.entity(entityName).all);
   return queryClient.invalidateQueries({ queryKey: queryKeys.entity(entityName).all });
 }
 
@@ -116,14 +118,9 @@ export function invalidateEntityCacheByName(entityName: string): Promise<void> {
 export function invalidateEntityCacheFromUrl(apiUrl?: string): void {
   if (!apiUrl) return;
 
-  const parts = apiUrl.split('/').filter(Boolean);
-  let entityName: string | undefined;
-  for (let i = parts.length - 1; i >= 0; i--) {
-    if (!parts[i].startsWith(':')) {
-      entityName = parts[i];
-      break;
-    }
-  }
+  const entityName = deriveEntityName(apiUrl);
+
+  console.log('[invalidateEntityCacheFromUrl] apiUrl:', apiUrl, 'derived entityName:', entityName);
 
   if (entityName && entityName !== 'unknown') {
     invalidateEntityCacheByName(entityName);

--- a/src/core/services/OperationExecutor.ts
+++ b/src/core/services/OperationExecutor.ts
@@ -42,6 +42,8 @@ export interface OperationConfig {
   // ===== Payload & Context =====
   payload?: any;
   routeParams?: Record<string, any>;
+  entityName?: string; // Entity name for cache invalidation (if apiUrl is substituted)
+  originalApiUrl?: string; // Original unsubstituted API URL for cache invalidation
 
   // ===== Modal Depth Override =====
   /** Override modal depth for z-index calculation of response modals */
@@ -275,7 +277,11 @@ export class OperationExecutor {
     }
 
     // Invalidate React Query cache for the affected entity (auto-derived from apiUrl)
-    invalidateEntityCacheFromUrl(config.apiConfig.apiUrl);
+    if (config.entityName) {
+      invalidateEntityCacheByName(config.entityName);
+    } else {
+      invalidateEntityCacheFromUrl(config.originalApiUrl || config.apiConfig.apiUrl);
+    }
 
     // Invalidate additional explicitly-specified related entities
     if (config.invalidateRelated?.length) {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -106,8 +106,19 @@ export const deriveEntityName = (apiUrl?: string, entityName?: string): string =
   if (entityName) return entityName;
   const url = apiUrl || '';
   const parts = url.split('/').filter(Boolean);
-  const lastPart = parts[ parts.length - 1 ] || 'unknown';
-  return lastPart.startsWith(':') ? (parts[ parts.length - 2 ] || 'unknown') : lastPart;
+
+  // Walk backwards to find the first part that is not a parameter, not an action verb, and not an ID
+  const actionVerbs = [ 'search', 'list', 'create', 'update', 'delete', 'duplicate' ];
+  const isId = (part: string) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i.test(part) || /^\d+$/.test(part);
+
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[ i ];
+    if (!part.startsWith(':') && !actionVerbs.includes(part.toLowerCase()) && !isId(part)) {
+      return part;
+    }
+  }
+
+  return parts[ parts.length - 1 ] || 'unknown';
 };
 
 /**

--- a/src/forms/Form.tsx
+++ b/src/forms/Form.tsx
@@ -544,6 +544,9 @@ export function Form({
             payload: formattedValues
           },
           routeParams,
+          entityName,
+          originalApiUrl: apiConfig.apiUrl,
+          invalidateRelated: entityName ? [entityName] : undefined,
           onLoading: (loading) => {
             setLoader(loading);
             setBtnLoader(loading);

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -482,6 +482,7 @@ export const Modal = ({
           ...apiConfig,
           apiUrl: formattedApiUrl
         },
+        originalApiUrl: apiConfig.apiUrl,
         routeParams,
         onLoading: setLoading,
         successMessage,


### PR DESCRIPTION
- Updated `deriveEntityName` utility to be smarter by ignoring common action verbs (`search`, `list`, `create`, `update`, `delete`, `duplicate`) and UUIDs/numeric IDs when deriving the entity name from an API URL.
- Passed the `originalApiUrl` and `entityName` to `OperationExecutor` from `Form` and `Modal` components to ensure the correct cache key is invalidated, even when the URL has been substituted with record IDs.
- Added `invalidateRelated` support in `Form` to explicitly invalidate the current entity's cache.