### PR TITLE
ci: align develop-release with fw24

### DIFF
--- a/.github/workflows/develop-release.yml
+++ b/.github/workflows/develop-release.yml
@@ -1,34 +1,56 @@
 name: Develop Branch Release
 
+# Runs when `develop` moves. Never pushes to `develop`.
+#
+# Flow: branch off `develop` → build → commit dist (if any) → standard-version (version/changelog/tag) →
+#       push tag + push `ci/release-<run_id>` → open PR into `develop`.
+#
+# Secret DEVELOP_RELEASE_TOKEN: PAT with repo + PR scope (Contents + Pull requests write) for this repo.
+#
+# Skips the next run when the push to `develop` is the merge of one of these PRs (avoids a release loop).
 on:
   push:
     branches:
       - develop
+  workflow_dispatch:
+
+concurrency:
+  group: develop-release-${{ github.repository }}
+  cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-and-release:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event.head_commit == null ||
+        !contains(github.event.head_commit.message, 'ci/release-')
+      }}
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEVELOP_RELEASE_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Branch off develop for release work
+        run: |
+          set -euo pipefail
+          git checkout -B "ci/release-${{ github.run_id }}"
 
       - name: Check and update package.json
         id: check_package
@@ -38,8 +60,6 @@ jobs:
 
           if [ "$MAIN" = "src/index.tsx" ] || [ "$TYPES" = "src/index.tsx" ]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
-
-            # Update package.json
             node -e "
               const fs = require('fs');
               const pkg = require('./package.json');
@@ -47,7 +67,6 @@ jobs:
               pkg.types = 'dist/index.d.ts';
               fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
             "
-
             echo "Updated package.json main and types"
           else
             echo "needs_update=false" >> $GITHUB_OUTPUT
@@ -75,6 +94,14 @@ jobs:
 
           if [ "${{ steps.check_package.outputs.needs_update }}" = "true" ]; then
             git add package.json
+          fi
+
+          if git diff --staged --quiet; then
+            echo "No build output changes to commit; continuing to version step"
+            exit 0
+          fi
+
+          if [ "${{ steps.check_package.outputs.needs_update }}" = "true" ]; then
             git commit -m "chore: update build config and dist [skip ci]"
             echo "Committed package.json and dist folder"
           else
@@ -82,7 +109,42 @@ jobs:
             echo "Committed dist folder"
           fi
 
-      - name: Release beta version
-        run: npm run release:BE:github
+      - name: Next beta version (skip if tag already exists)
+        id: next_rel
+        run: echo "version=$(node scripts/ci/next-free-beta-version.cjs)" >> "$GITHUB_OUTPUT"
+
+      - name: Release beta (standard-version + tag)
+        id: rel
+        run: |
+          set -euo pipefail
+          npm run release:BE:version:as -- --release-as "${{ steps.next_rel.outputs.version }}"
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag and open PR to develop
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEVELOP_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.rel.outputs.version }}"
+          TAG="${{ steps.rel.outputs.tag }}"
+          BRANCH="ci/release-${{ github.run_id }}"
+          BODY_FILE="${RUNNER_TEMP}/develop-release-pr-body.md"
+
+          git push origin "refs/tags/${TAG}"
+          git push origin "HEAD:refs/heads/${BRANCH}"
+
+          printf '%s\n' \
+            "Automated release from \`develop\` (workflow [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))." \
+            "" \
+            "- **Tag** \`${TAG}\` has been pushed." \
+            "- This branch contains the version bump (\`${VERSION}\`), changelog, and any \`dist\` updates." \
+            "- **Merge this PR** to update \`develop\` (nothing pushes to \`develop\` from Actions)." \
+            "" \
+            "The merge commit message includes \`ci/release-\`, so merging does **not** re-trigger this workflow." \
+            > "${BODY_FILE}"
+
+          gh pr create --repo "${{ github.repository }}" --base develop --head "${BRANCH}" \
+            --title "chore(release): ${VERSION}" \
+            --body-file "${BODY_FILE}"

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,3 @@
+{
+  "releaseCommitMessageFormat": "chore(release): {{currentTag}} [skip ci]"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.8.0",
+        "semver": "^7.7.2",
         "standard-version": "^9.5.0",
         "style-loader": "^3.3.4",
         "ts-jest": "^29.4.1",
@@ -922,6 +923,16 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
@@ -968,6 +979,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
@@ -990,6 +1011,16 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
@@ -1006,6 +1037,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -2621,6 +2662,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -7357,6 +7408,16 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
@@ -8509,6 +8570,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/conventional-commits-filter": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
@@ -8716,19 +8787,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/css-loader/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/css-select": {
@@ -10778,6 +10836,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/git-semver-tags/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/gitconfiglocal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
@@ -12226,19 +12294,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -13082,19 +13137,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
@@ -13706,19 +13748,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -15106,19 +15135,6 @@
         "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -18005,13 +18021,16 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -18708,19 +18727,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/standard-version/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/standard-version/node_modules/string-width": {
@@ -19614,19 +19620,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-jest/node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -19656,19 +19649,6 @@
       "peerDependencies": {
         "typescript": "*",
         "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/ts-loader/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ts-loader/node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "watch": "webpack --watch",
     "release": "npm run build && standard-version && git push --follow-tags && npm publish",
     "release:BE": "npm run build && standard-version --prerelease beta && git push --follow-tags && npm publish --tag bleeding-edge",
-    "release:BE:github": "npm run build && standard-version --prerelease beta && git push --follow-tags"
+    "release:BE:github": "npm run build && standard-version --prerelease beta && git push --follow-tags",
+    "release:BE:version:as": "standard-version",
+    "release:BE:next-free-beta": "node scripts/ci/next-free-beta-version.cjs"
   },
   "keywords": [
     "ui24",
@@ -82,6 +84,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.8.0",
+    "semver": "^7.7.2",
     "standard-version": "^9.5.0",
     "style-loader": "^3.3.4",
     "ts-jest": "^29.4.1",

--- a/scripts/ci/next-free-beta-version.cjs
+++ b/scripts/ci/next-free-beta-version.cjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Print the next 1.1.0-beta.N semver such that refs/tags/v<that> does not exist locally
+ * or on origin (avoids standard-version failing when a tag was pushed but develop was not).
+ */
+'use strict';
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const semver = require('semver');
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+function tagExists(tagName) {
+  const ref = `refs/tags/${tagName}`;
+  try {
+    execSync(`git rev-parse -q --verify "${ref}"`, { stdio: 'ignore' });
+    return true;
+  } catch (_) {}
+  try {
+    const out = execSync(`git ls-remote origin "${ref}"`, { encoding: 'utf8' });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+let candidate = semver.inc(pkg.version, 'prerelease', 'beta');
+if (!candidate) {
+  throw new Error(`cannot bump prerelease from ${pkg.version}`);
+}
+let steps = 0;
+while (tagExists(`v${candidate}`)) {
+  if (++steps > 500) {
+    throw new Error('too many occupied prerelease tags');
+  }
+  const next = semver.inc(candidate, 'prerelease', 'beta');
+  if (!next || semver.eq(next, candidate)) {
+    throw new Error(`stuck at ${candidate}`);
+  }
+  candidate = next;
+}
+
+process.stdout.write(candidate);


### PR DESCRIPTION
- Same flow as **fw24**: build on `ci/release-<run>`, `standard-version` with next free beta tag, push tag + branch, **open PR to develop** (no direct `develop` push).\n- Adds `scripts/ci/next-free-beta-version.cjs`, `.versionrc.json`, and `release:BE:version:as` / `release:BE:next-free-beta` scripts.\n- **DEVELOP_RELEASE_TOKEN** is set on the repo for Actions.