### PR TITLE
fix(forms): select labels and row-action modal submit URLs for staff role

### DIFF
--- a/src/core/forms/FormField/OptionSelector.tsx
+++ b/src/core/forms/FormField/OptionSelector.tsx
@@ -6,7 +6,7 @@ import { useEntityConfig, type IEntityConfigReference } from '../../hooks';
 import type { IFormField, IOptions, ITemplateConfig, IQuickCreateConfig } from '../../types/field-config';
 import { interpolateTemplate } from '../../utils/template';
 import { deriveEntityName } from '../../utils';
-import { useInfiniteFieldOptions } from '../../query/useFieldOptions';
+import { useFieldOptions, useInfiniteFieldOptions } from '../../query/useFieldOptions';
 
 /**
  * Configuration for API-loaded options in form field selectors.
@@ -128,6 +128,7 @@ interface IOptionSelector {
     addNewOptionConfig?: IEntityConfigReference, // NEW: Entity config reference
     value?: string,
     placeholder?: string;
+    disabled?: boolean;
     /** Additional filters from parent field dependencies (e.g., country → state cascading) */
     dependencyFilters?: Record<string, unknown>;
     /**
@@ -233,6 +234,7 @@ export const OptionSelector = ({
     onOptionChange, 
     value,
     placeholder,
+    disabled = false,
     dependencyFilters,
 }: IOptionSelector) => {
 
@@ -290,6 +292,38 @@ export const OptionSelector = ({
 
     const isSelectLike = [ 'select', 'multi-select', 'checkbox', 'radio' ].includes(fieldType.toLowerCase());
 
+    const valueFieldName = typeof apiConfig?.optionMapping?.value === 'string'
+        ? apiConfig.optionMapping.value
+        : '';
+
+    const selectedValueKeys = useMemo(() => {
+        if (value === undefined || value === null || value === '') return [] as string[];
+        const raw = Array.isArray(value) ? value : [ value ];
+        return raw
+            .filter((entry) => entry !== undefined && entry !== null && entry !== '')
+            .map((entry) => String(entry));
+    }, [ value ]);
+
+    // Proactive lookup for the current value(s) so chips/labels resolve without opening the dropdown.
+    const selectedRecordsQuery = useFieldOptions({
+        entityName: `${optionsEntityName}-selected`,
+        fieldName: valueFieldName ? `${valueFieldName}-lookup` : 'lookup',
+        apiConfig: {
+            apiMethod: hookApiConfig.apiMethod,
+            apiUrl: hookApiConfig.apiUrl,
+            responseKey: hookApiConfig.responseKey,
+            disableSearch: true,
+            count: Math.max(selectedValueKeys.length, 1),
+            filters: selectedValueKeys.length === 1
+                ? { [ valueFieldName ]: selectedValueKeys[ 0 ] }
+                : { [ `${valueFieldName}.inList` ]: selectedValueKeys.join(',') },
+        },
+        enabled: isApiConfig && isSelectLike && !!valueFieldName && selectedValueKeys.length > 0,
+    });
+
+    // Browse list: eager for editable fields; disabled display-only fields skip bulk fetch.
+    const shouldFetchOptionList = isApiConfig && isSelectLike && !disabled;
+
     const {
         options: apiOptions,
         hasMore,
@@ -303,14 +337,30 @@ export const OptionSelector = ({
         fieldName: typeof apiConfig?.optionMapping?.value === 'string' ? apiConfig.optionMapping.value : '',
         apiConfig: hookApiConfig,
         dependencyFilters,
-        enabled: isApiConfig && isSelectLike,
+        enabled: shouldFetchOptionList,
         mapOption: apiConfig?.optionMapping ? mapOption : undefined,
         searchDebounce: apiConfig?.searchDebounce || 500,
     });
 
-    // Final options: API-loaded (from hook) or static (from props)
     const fieldOptions = isApiConfig ? apiOptions : (Array.isArray(options) ? options : []);
-    const loading = isLoading || isFetching;
+
+    const resolvedFieldOptions = useMemo(() => {
+        if (!isApiConfig || !apiConfig?.optionMapping) return fieldOptions;
+
+        const selectedOptions = (selectedRecordsQuery.data ?? []).map((record) => mapOption(record));
+        if (!selectedOptions.length) return fieldOptions;
+
+        const merged = [ ...selectedOptions ];
+        for (const option of fieldOptions) {
+            if (!merged.some((existing) => String(existing.value) === String(option.value))) {
+                merged.push(option);
+            }
+        }
+        return merged.sort((a, b) => String(a.label ?? '').localeCompare(String(b.label ?? '')));
+    }, [ isApiConfig, fieldOptions, selectedRecordsQuery.data, apiConfig?.optionMapping, mapOption ]);
+
+    const loading = (shouldFetchOptionList && (isLoading || isFetching))
+        || (selectedValueKeys.length > 0 && (selectedRecordsQuery.isLoading || selectedRecordsQuery.isFetching));
 
     // Check if API config has remote search enabled
     const hasRemoteSearch = isApiConfig && apiConfig?.disableSearch !== true;
@@ -501,7 +551,7 @@ export const OptionSelector = ({
         {fieldType === "checkbox" && (
             <Checkbox.Group 
                 value={[ value ]} 
-                options={fieldOptions} 
+                options={resolvedFieldOptions} 
                 onChange={(checkedValues) => onOptionChange?.(checkedValues)}
             />
         )}
@@ -509,7 +559,7 @@ export const OptionSelector = ({
         {fieldType === "radio" && (
             <Radio.Group 
                 value={value} 
-                options={fieldOptions} 
+                options={resolvedFieldOptions} 
                 onChange={(e) => onOptionChange?.(e.target.value)}
             />
         )}
@@ -517,6 +567,8 @@ export const OptionSelector = ({
         {fieldType === "select" && (
             <AntSelect 
                 value={value} 
+                disabled={disabled}
+                allowClear={!disabled}
                 loading={loading}
                 showSearch
                 filterOption={filterOption}
@@ -526,7 +578,7 @@ export const OptionSelector = ({
                     if (!visible) setSearchTerm('');
                 }} 
                 open={open} 
-                options={fieldOptions}
+                options={resolvedFieldOptions}
                 popupRender={canLoadMore || hasAddNewOption ? customDropdownRender : undefined}
                 onChange={(value) => { setSearchTerm(''); onOptionChange?.(value); }}
                 notFoundContent={notFoundContent}
@@ -539,6 +591,8 @@ export const OptionSelector = ({
         {fieldType === "multi-select" && (
             <AntSelect 
                 value={value}
+                disabled={disabled}
+                allowClear={!disabled}
                 loading={loading}
                 showSearch
                 filterOption={filterOption}
@@ -548,7 +602,7 @@ export const OptionSelector = ({
                     if (!visible) setSearchTerm('');
                 }} 
                 open={open} 
-                options={fieldOptions}
+                options={resolvedFieldOptions}
                 popupRender={canLoadMore || hasAddNewOption ? customDropdownRender : undefined}
                 onChange={(value) => { setSearchTerm(''); onOptionChange?.(value); }}
                 mode='multiple'

--- a/src/core/registry/field-types/select.tsx
+++ b/src/core/registry/field-types/select.tsx
@@ -8,7 +8,7 @@ import type { FieldTypeRegistration } from '../FieldTypeRegistry';
 // pre-populated value when the form first loads and is NOT kept in sync after mount.
 // Using `initialValue` here would break programmatic updates (form.setFieldValue etc.).
 
-const SelectForm: React.FC<BuiltInFormFieldProps> = ({ value, fieldType, options, addNewOption, addNewOptionConfig, quickCreate, setFormValue, name, placeholder, dependencyFilters }) => (
+const SelectForm: React.FC<BuiltInFormFieldProps> = ({ value, fieldType, options, addNewOption, addNewOptionConfig, quickCreate, setFormValue, name, placeholder, dependencyFilters, disabled, readOnly }) => (
   <OptionSelector
     value={value}
     fieldType={fieldType}
@@ -21,10 +21,11 @@ const SelectForm: React.FC<BuiltInFormFieldProps> = ({ value, fieldType, options
     }}
     placeholder={placeholder}
     dependencyFilters={dependencyFilters}
+    disabled={disabled || readOnly}
   />
 );
 
-const MultiSelectForm: React.FC<BuiltInFormFieldProps> = ({ value, fieldType, options, addNewOption, addNewOptionConfig, quickCreate, setFormValue, name, placeholder, dependencyFilters }) => (
+const MultiSelectForm: React.FC<BuiltInFormFieldProps> = ({ value, fieldType, options, addNewOption, addNewOptionConfig, quickCreate, setFormValue, name, placeholder, dependencyFilters, disabled, readOnly }) => (
   <OptionSelector
     value={value}
     fieldType={fieldType}
@@ -37,6 +38,7 @@ const MultiSelectForm: React.FC<BuiltInFormFieldProps> = ({ value, fieldType, op
     }}
     placeholder={placeholder}
     dependencyFilters={dependencyFilters}
+    disabled={disabled || readOnly}
   />
 );
 

--- a/src/core/registry/field-types/types.ts
+++ b/src/core/registry/field-types/types.ts
@@ -38,6 +38,8 @@ export interface BuiltInFormFieldProps extends Partial<IFormField> {
   onChange?: (...args: any[]) => void;
   checked?: boolean;
   id?: string;
+  /** Set by FormField when enablement condition evaluates to false */
+  disabled?: boolean;
 
   // --- Rich content / code editor properties ---
   theme?: string;

--- a/src/core/utils/actionRenderer.tsx
+++ b/src/core/utils/actionRenderer.tsx
@@ -6,10 +6,30 @@ import { OpenRouteInModal } from "../../modal/OpenRouteInModal";
 import { OpenRouteInDrawer } from "../../modal/OpenRouteInDrawer";
 import { OpenInDrawer } from "../../modal/Drawer";
 import { IPageAction } from "../../table/type";
-import { substituteUrlParams } from "../utils";
+import { substituteUrlParams, extractUrlParamNames } from "../utils";
 import { evaluateTemplateValue } from "../utils/template";
 import { isExternalUrl, resolveAnchorProps } from "../utils/link-utils";
 import { executeCopyToClipboard } from "../utils/copyUtils";
+
+/** Row id is only passed to forms when the modal submit URL has `:param` placeholders to fill. */
+function rowIdentifiersForSubmitUrl(
+  submitApiUrl: string | undefined,
+  primaryIndex?: string,
+  routeParams?: Record<string, string>,
+): string | undefined {
+  if (!submitApiUrl || extractUrlParamNames(submitApiUrl).length === 0) {
+    return undefined;
+  }
+  return primaryIndex || routeParams?.id;
+}
+
+function getSubmitApiUrl(pageConfig: unknown): string | undefined {
+  if (!pageConfig || typeof pageConfig !== 'object' || !('apiConfig' in pageConfig)) {
+    return undefined;
+  }
+  const apiConfig = (pageConfig as { apiConfig?: { apiUrl?: string } }).apiConfig;
+  return typeof apiConfig?.apiUrl === 'string' ? apiConfig.apiUrl : undefined;
+}
 
 export type MenuItem = Required<MenuProps>[ 'items' ][ number ];
 
@@ -91,6 +111,11 @@ export function renderSingleAction({
     // Merge record data with routeParams for template resolution (initialValues)
     // Priority: record data overrides routeParams
     const finalRouteParams = record ? { ...routeParams, ...record } : routeParams;
+    const rowIdentifier = rowIdentifiersForSubmitUrl(
+      getSubmitApiUrl(action.modalConfig.modalPageConfig),
+      primaryIndex,
+      routeParams,
+    );
 
     const modalTrigger = (
       <OpenInModal
@@ -99,7 +124,7 @@ export function renderSingleAction({
         modalWidth={action.modalWidth}  // Pass modalWidth from action level
         modalTitle={action.modalTitle}  // Pass modalTitle from action level (if set)
         primaryIndex={primaryIndex || routeParams.id}
-        identifiers={primaryIndex || routeParams.id}  // Pass identifiers for Form component
+        identifiers={rowIdentifier}
         routeParams={finalRouteParams}  // Include record data for template resolution
         onSuccessCallback={onSuccessCallback}
       >
@@ -170,6 +195,11 @@ export function renderSingleAction({
   // Supports inline page config (drawerType + drawerPageConfig)
   if (action.openInDrawer && action.drawerConfig?.drawerType && action.drawerConfig?.drawerPageConfig) {
     const finalRouteParams = record ? { ...routeParams, ...record } : routeParams;
+    const rowIdentifier = rowIdentifiersForSubmitUrl(
+      getSubmitApiUrl(action.drawerConfig.drawerPageConfig),
+      primaryIndex,
+      routeParams,
+    );
 
     const drawerTrigger = (
       <OpenInDrawer
@@ -187,7 +217,7 @@ export function renderSingleAction({
         maskClosable={action.drawerConfig.maskClosable}
         destroyOnClose={action.drawerConfig.destroyOnClose}
         routeParams={finalRouteParams}
-        identifiers={primaryIndex || routeParams.id}
+        identifiers={rowIdentifier}
         onSuccess={onSuccessCallback}
       >
         {wrapWithTooltip(

--- a/src/forms/Form.tsx
+++ b/src/forms/Form.tsx
@@ -465,7 +465,11 @@ export function Form({
     // ============================================================================
     if (apiConfig) {
       // Use the clean utility function for URL parameter substitution
-      const formattedApiUrl = substituteUrlParams(apiConfig.apiUrl, routeParams, identifiersToUse);
+      const formattedApiUrl = substituteUrlParams(
+        apiConfig.apiUrl,
+        routeParams,
+        identifiersToUse,
+      );
 
       // ============================================================================
       // Form Data Processing (Dates, JSON, Numbers, Nested Objects)


### PR DESCRIPTION
## Problem

Staff role assignment opens a row-action modal with disabled Member/Team selects prefilled from the row. Two ui24 gaps blocked it:

- Selected values showed raw UUIDs when the record was not in the first page of options.
- Row actions always passed the row identifier into modal forms, so body-only submit URLs like `PATCH /admin/userteam/assign-staff-role` were rewritten to `.../assign-staff-role/{userId}` and failed at the gateway.

## Intent

Disabled selects should show human-readable labels without opening the dropdown. Custom PATCH endpoints with no `:id` in the path should submit to the configured URL with body fields only.

## Approach

- **OptionSelector:** proactive lookup of the current value by id filter; skip bulk option fetch when the field is disabled; pass `disabled`/`readOnly` through select field types.
- **actionRenderer:** pass `identifiers` into row-action modals only when the modal submit `apiUrl` contains `:param` placeholders. Legacy `substituteUrlParams` append behavior in `Form.tsx` is unchanged.

## Solution

- Proactive selected-record fetch merges into options for chip/label display.
- Editable selects still load the browse list on mount; disabled display fields do not bulk-fetch.
- Row-action modals with placeholder-free submit URLs no longer receive a row id for URL substitution.

## Test plan

- [ ] Open Team → Team Members → Staff role on a member with existing role
- [ ] Member and Team show names (not UUIDs) before opening any dropdown
- [ ] Member and Team fields are disabled; Staff role is editable and team-scoped
- [ ] Submit succeeds against `PATCH /admin/userteam/assign-staff-role` (no userId suffix in path)
- [ ] Row-action modal that uses `/admin/template/:id` still substitutes the row id correctly
- [ ] `npm run typecheck` passes for changed files

## Deploy / dependencies

Pair with plusfan-app-backend PR for the userTeam row-action modal config. Merge ui24 first (or bump admin dependency) before QA on admin.