### PR TITLE
fix(forms): cascading selects never sent the parent value; add optional option thumbnails

### DIFF
--- a/src/core/forms/FormField/FormField.tsx
+++ b/src/core/forms/FormField/FormField.tsx
@@ -11,6 +11,7 @@ import { fieldTypeRegistry } from '../../registry/FieldTypeRegistry';
 import { useRenderPipeline } from '../../rendering';
 import '../../registry/field-types'; // ensure built-in registrations run
 import type { BuiltInFormFieldProps } from '../../registry/field-types/types';
+import { useDependencyFilters } from './useDependencyFilters';
 
 /**
  * Internal form field props type where ConditionalValue fields have been resolved to strings.
@@ -55,32 +56,10 @@ const MakeFormItem = ({
     const formValues = form?.getFieldsValue(true) || {};
     const fieldConfig = { fieldType, name, label, placeholder, helpText, ...restFormItemProps };
     const pipelineResult = processField(fieldConfig, initialValue, formValues);
-    const dependencyFilters = React.useMemo(() => {
-        if (!dependsOn || !form) return undefined;
-        const deps = Array.isArray(dependsOn) ? dependsOn : [ dependsOn ];
-        const filters: Record<string, unknown> = {};
-        let hasValue = false;
-        for (const dep of deps) {
-            const val = form.getFieldValue(dep);
-            if (val !== undefined && val !== null && val !== '') {
-                filters[ dep ] = val;
-                hasValue = true;
-            }
-        }
-        return hasValue ? filters : undefined;
-    }, [ dependsOn, form ]);
 
-    // Force re-render when dependency fields change by watching all form values
-    // (antd's Form.useWatch with no specific field watches all values)
-    const watchedDeps = Form.useWatch(
-        dependsOn
-            ? (values: Record<string, unknown>) => {
-                const deps = Array.isArray(dependsOn) ? dependsOn : [ dependsOn ];
-                return deps.map(d => values?.[ d ]);
-            }
-            : () => null,
-        form
-    );
+    // Cascading selects (#3): the parent values this field's options depend on.
+    // See useDependencyFilters for why this cannot be a plain mount-time memo.
+    const { dependencyFilters, watchedDeps } = useDependencyFilters(dependsOn, form);
 
     // Clear this field's value when parent dependency value changes (#3)
     const prevDepsRef = React.useRef<unknown[] | null>(null);

--- a/src/core/forms/FormField/OptionSelector.tsx
+++ b/src/core/forms/FormField/OptionSelector.tsx
@@ -225,6 +225,33 @@ interface IOptionSelector {
  *   }}
  * />
  */
+/** Fixed thumbnail box, so rows stay aligned whether or not an image loads. */
+const THUMB_SIZE = 22;
+
+/**
+ * Renders an option's thumbnail next to its label.
+ *
+ * The image is decoration: `label` remains the option's text identity, so search,
+ * keyboard selection and screen readers are unaffected. A broken or missing image
+ * collapses to an empty box of the same size rather than shifting the row.
+ */
+const OptionRow: React.FC<{ option: IOptions }> = ({ option }) => (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+        {option.image
+            ? <img
+                src={option.image}
+                alt=""
+                aria-hidden="true"
+                width={THUMB_SIZE}
+                height={THUMB_SIZE}
+                loading="lazy"
+                style={{ width: THUMB_SIZE, height: THUMB_SIZE, objectFit: 'contain', flexShrink: 0 }}
+            />
+            : <span aria-hidden="true" style={{ width: THUMB_SIZE, height: THUMB_SIZE, flexShrink: 0 }} />}
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{option.label}</span>
+    </span>
+);
+
 export const OptionSelector = ({ 
     options = [], 
     fieldType, 
@@ -361,6 +388,45 @@ export const OptionSelector = ({
 
     const loading = (shouldFetchOptionList && (isLoading || isFetching))
         || (selectedValueKeys.length > 0 && (selectedRecordsQuery.isLoading || selectedRecordsQuery.isFetching));
+
+    // Only opt into custom rendering when there is actually an image to show, so
+    // fields without images keep antd's default rendering untouched.
+    const hasOptionImages = useMemo(
+        () => resolvedFieldOptions.some((option) => !!option.image),
+        [ resolvedFieldOptions ]
+    );
+
+    /** Dropdown row renderer — receives the original option, image included. */
+    const optionRender = useCallback(
+        (option: { data: IOptions }) => <OptionRow option={option.data} />,
+        []
+    );
+
+    /**
+     * Renderer for the chosen value(s). antd hands back only label/value, so the
+     * image is looked up from the option list by value.
+     */
+    const labelRender = useCallback(
+        ({ label, value: selectedValue }: { label?: React.ReactNode; value?: string | number }) => {
+            const match = resolvedFieldOptions.find(
+                (option) => String(option.value) === String(selectedValue)
+            );
+            if (!match) return label ?? selectedValue;
+            return <OptionRow option={match} />;
+        },
+        [ resolvedFieldOptions ]
+    );
+
+    /** Radio has no optionRender, so its labels are built as nodes up front. */
+    const radioOptions = useMemo(
+        () => (hasOptionImages
+            ? resolvedFieldOptions.map((option) => ({
+                value: option.value,
+                label: <OptionRow option={option} />,
+            }))
+            : resolvedFieldOptions),
+        [ hasOptionImages, resolvedFieldOptions ]
+    );
 
     // Check if API config has remote search enabled
     const hasRemoteSearch = isApiConfig && apiConfig?.disableSearch !== true;
@@ -559,7 +625,7 @@ export const OptionSelector = ({
         {fieldType === "radio" && (
             <Radio.Group 
                 value={value} 
-                options={resolvedFieldOptions} 
+                options={radioOptions as any} 
                 onChange={(e) => onOptionChange?.(e.target.value)}
             />
         )}
@@ -579,6 +645,7 @@ export const OptionSelector = ({
                 }} 
                 open={open} 
                 options={resolvedFieldOptions}
+                {...(hasOptionImages ? { optionRender, labelRender } : {})}
                 popupRender={canLoadMore || hasAddNewOption ? customDropdownRender : undefined}
                 onChange={(value) => { setSearchTerm(''); onOptionChange?.(value); }}
                 notFoundContent={notFoundContent}
@@ -603,6 +670,7 @@ export const OptionSelector = ({
                 }} 
                 open={open} 
                 options={resolvedFieldOptions}
+                {...(hasOptionImages ? { optionRender, labelRender } : {})}
                 popupRender={canLoadMore || hasAddNewOption ? customDropdownRender : undefined}
                 onChange={(value) => { setSearchTerm(''); onOptionChange?.(value); }}
                 mode='multiple'

--- a/src/core/forms/FormField/__tests__/optionSelectorImages.test.tsx
+++ b/src/core/forms/FormField/__tests__/optionSelectorImages.test.tsx
@@ -1,0 +1,116 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Option thumbnails for select / multi-select / radio fields.
+ *
+ * Some choices are recognised visually — a team by its crest — and a URL printed
+ * in the label text is not a usable substitute. These tests pin the two things
+ * that make the feature safe: the image is added without disturbing the label's
+ * role as the option's text identity (search, a11y), and fields whose options
+ * carry no image keep antd's default rendering.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+jest.mock('../../../../modal/Modal', () => ({
+  OpenInModal: ({ children }: any) => <>{children}</>,
+  useModalDepth: () => 0,
+  ModalDepthContext: React.createContext(0),
+}));
+
+jest.mock('../../../hooks', () => ({
+  useEntityConfig: () => ({ resolveConfigRef: () => undefined }),
+}));
+
+jest.mock('../../../context/ApiContext', () => ({
+  useApi: () => ({ callApiMethod: jest.fn().mockResolvedValue({ status: 200, data: { items: [] } }) }),
+}));
+
+import { OptionSelector } from '../OptionSelector';
+
+const TEAMS = [
+  { label: 'Barcelona · Spain · id 529', value: '529', image: 'https://logos/529.png' },
+  { label: 'Barcelona SC · Ecuador · id 9001', value: '9001', image: 'https://logos/9001.png' },
+];
+
+function renderSelector(props: Record<string, any>) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <OptionSelector fieldType="select" onOptionChange={jest.fn()} {...(props as any)} />
+    </QueryClientProvider>
+  );
+}
+
+const logos = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('img')).map(img => img.getAttribute('src'));
+
+describe('option thumbnails', () => {
+  it('renders each option image in the radio list', () => {
+    const { container } = renderSelector({ fieldType: 'radio', options: TEAMS });
+
+    expect(logos(container)).toEqual([ 'https://logos/529.png', 'https://logos/9001.png' ]);
+  });
+
+  it('keeps the label text alongside the image, so the option stays searchable and readable', () => {
+    renderSelector({ fieldType: 'radio', options: TEAMS });
+
+    expect(screen.getByText('Barcelona · Spain · id 529')).toBeInTheDocument();
+    expect(screen.getByText('Barcelona SC · Ecuador · id 9001')).toBeInTheDocument();
+  });
+
+  it('marks images as decorative so they are not announced twice', () => {
+    const { container } = renderSelector({ fieldType: 'radio', options: TEAMS });
+
+    for (const img of Array.from(container.querySelectorAll('img'))) {
+      expect(img).toHaveAttribute('alt', '');
+      expect(img).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+
+  it('renders images in the select dropdown', async () => {
+    const { container } = renderSelector({ fieldType: 'select', options: TEAMS });
+
+    fireEvent.mouseDown(container.querySelector('.ant-select-selector')!);
+
+    // antd renders the dropdown into a portal on document.body, not in `container`.
+    await waitFor(() => expect(logos(document.body).length).toBeGreaterThan(0));
+    expect(logos(document.body)).toContain('https://logos/529.png');
+    expect(logos(document.body)).toContain('https://logos/9001.png');
+  });
+
+  it('shows the chosen option with its image', () => {
+    const { container } = renderSelector({ fieldType: 'select', options: TEAMS, value: '529' });
+
+    expect(logos(container)).toContain('https://logos/529.png');
+  });
+
+  it('reserves the thumbnail slot for an option with no image, so rows stay aligned', () => {
+    const { container } = renderSelector({
+      fieldType: 'radio',
+      options: [ TEAMS[ 0 ], { label: 'No crest · id 7', value: '7' } ],
+    });
+
+    // One <img> for the option that has one; the other renders a same-size spacer.
+    expect(container.querySelectorAll('img')).toHaveLength(1);
+    expect(screen.getByText('No crest · id 7')).toBeInTheDocument();
+  });
+
+  it('renders no images at all when no option has one', () => {
+    const { container } = renderSelector({
+      fieldType: 'radio',
+      options: [ { label: 'Football', value: 'football' }, { label: 'Hockey', value: 'hockey' } ],
+    });
+
+    expect(container.querySelectorAll('img')).toHaveLength(0);
+    expect(container.querySelectorAll('span[aria-hidden="true"]')).toHaveLength(0);
+    expect(screen.getByText('Football')).toBeInTheDocument();
+  });
+
+  it('renders images for multi-select too', () => {
+    const { container } = renderSelector({ fieldType: 'multi-select', options: TEAMS, value: [ '529' ] });
+
+    expect(logos(container)).toContain('https://logos/529.png');
+  });
+});

--- a/src/core/forms/FormField/__tests__/useDependencyFilters.test.tsx
+++ b/src/core/forms/FormField/__tests__/useDependencyFilters.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Regression tests for `dependsOn` cascading selects (#3).
+ *
+ * The bug this guards: `dependencyFilters` was memoized on `[dependsOn, form]`,
+ * both stable for the component's lifetime, so it was computed once at mount —
+ * when every parent field is still empty — and never again. A dependent select
+ * therefore fetched its options with no parent filter at all, which on the wire is
+ * indistinguishable from a form where nothing had been selected.
+ *
+ * Tests drive a real antd Form so the `Form.useWatch` behaviour is the real thing.
+ */
+
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { Form, Input } from 'antd';
+import { useDependencyFilters } from '../useDependencyFilters';
+
+/** Renders the hook inside a real antd Form and reports every value it produced. */
+function setup(dependsOn: string | string[] | undefined, initialValues: Record<string, unknown> = {}) {
+  const seen: Array<Record<string, unknown> | undefined> = [];
+  let formRef: any;
+
+  const Probe: React.FC = () => {
+    const form = Form.useFormInstance();
+    const { dependencyFilters, watchedDeps } = useDependencyFilters(dependsOn, form);
+    seen.push(dependencyFilters);
+    return (
+      <>
+        <span data-testid="filters">{JSON.stringify(dependencyFilters ?? null)}</span>
+        <span data-testid="watched">{JSON.stringify(watchedDeps ?? null)}</span>
+      </>
+    );
+  };
+
+  let bumpRef: () => void = () => {};
+
+  const Harness: React.FC = () => {
+    const [ form ] = Form.useForm();
+    const [ , setTick ] = React.useState(0);
+    formRef = form;
+    bumpRef = () => setTick(t => t + 1);
+    return (
+      <Form form={form} initialValues={initialValues}>
+        <Form.Item name="teamId"><Input /></Form.Item>
+        <Form.Item name="season"><Input /></Form.Item>
+        <Probe />
+      </Form>
+    );
+  };
+
+  render(<Harness />);
+
+  return {
+    seen,
+    filters: () => JSON.parse(screen.getByTestId('filters').textContent || 'null'),
+    watched: () => JSON.parse(screen.getByTestId('watched').textContent || 'null'),
+    set: (values: Record<string, unknown>) => act(() => { formRef.setFieldsValue(values); }),
+    /** Force a re-render of the whole form from outside, without touching values. */
+    rerender: () => act(() => { bumpRef(); }),
+  };
+}
+
+describe('useDependencyFilters', () => {
+  it('returns undefined while the parent is empty', () => {
+    const { filters } = setup('teamId');
+
+    // Not `{ teamId: '' }` — the backend must be able to tell "not chosen yet"
+    // from "chosen as empty" and skip work until the form is ready.
+    expect(filters()).toBeNull();
+  });
+
+  it('picks up the parent value after it is set — the regression', () => {
+    const { filters, set } = setup('teamId');
+
+    expect(filters()).toBeNull();
+
+    set({ teamId: 'team-1' });
+
+    expect(filters()).toEqual({ teamId: 'team-1' });
+  });
+
+  it('tracks further changes to the parent', () => {
+    const { filters, set } = setup('teamId');
+
+    set({ teamId: 'team-1' });
+    expect(filters()).toEqual({ teamId: 'team-1' });
+
+    set({ teamId: 'team-2' });
+    expect(filters()).toEqual({ teamId: 'team-2' });
+  });
+
+  it('goes back to undefined when the parent is cleared', () => {
+    const { filters, set } = setup('teamId');
+
+    set({ teamId: 'team-1' });
+    set({ teamId: undefined });
+
+    expect(filters()).toBeNull();
+  });
+
+  it('reads a value present from the start', () => {
+    const { filters } = setup('teamId', { teamId: 'team-preset' });
+
+    expect(filters()).toEqual({ teamId: 'team-preset' });
+  });
+
+  it('includes every dependency when dependsOn is a list', () => {
+    const { filters, set } = setup([ 'teamId', 'season' ]);
+
+    set({ teamId: 'team-1', season: '2026' });
+
+    expect(filters()).toEqual({ teamId: 'team-1', season: '2026' });
+  });
+
+  it('omits the dependencies that are still empty', () => {
+    const { filters, set } = setup([ 'teamId', 'season' ]);
+
+    set({ teamId: 'team-1' });
+
+    expect(filters()).toEqual({ teamId: 'team-1' });
+  });
+
+  it('treats an empty string as not set', () => {
+    const { filters, set } = setup('teamId');
+
+    set({ teamId: '' });
+
+    expect(filters()).toBeNull();
+  });
+
+  it('returns undefined when the field has no dependsOn', () => {
+    const { filters, set } = setup(undefined);
+
+    set({ teamId: 'team-1' });
+
+    expect(filters()).toBeNull();
+  });
+
+  it('keeps one object identity across re-renders that change nothing', () => {
+    const { seen, set, rerender } = setup('teamId');
+
+    set({ teamId: 'team-1' });
+    // The filter object feeds a react-query key: a fresh object on every render
+    // would invalidate the key and refetch the options forever.
+    rerender();
+    rerender();
+
+    const settled = seen.filter(Boolean) as Array<Record<string, unknown>>;
+    expect(settled.length).toBeGreaterThan(1);
+    expect(new Set(settled).size).toBe(1);
+  });
+
+  it('does not re-render the field when an unwatched value changes', () => {
+    const { seen, set } = setup('teamId');
+    const before = seen.length;
+
+    set({ season: '2026' });
+
+    expect(seen.length).toBe(before);
+  });
+
+  it('exposes the watched values so a stale child selection can be cleared', () => {
+    const { watched, set } = setup([ 'teamId', 'season' ]);
+
+    set({ teamId: 'team-1', season: '2026' });
+
+    expect(watched()).toEqual([ 'team-1', '2026' ]);
+  });
+
+  it('preserves non-string parent values as the form holds them', () => {
+    const { filters, set } = setup('teamId');
+
+    set({ teamId: [ 'a', 'b' ] });
+
+    expect(filters()).toEqual({ teamId: [ 'a', 'b' ] });
+  });
+});

--- a/src/core/forms/FormField/useDependencyFilters.ts
+++ b/src/core/forms/FormField/useDependencyFilters.ts
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Form } from 'antd';
+import type { FormInstance } from 'antd';
+
+export interface DependencyFiltersResult {
+  /** Parent values to filter the options request by, or `undefined` when none are set. */
+  dependencyFilters: Record<string, unknown> | undefined;
+  /** Current parent values, in `dependsOn` order. `null` when the field has no parents. */
+  watchedDeps: unknown[] | null;
+}
+
+/**
+ * Resolves the `dependsOn` values of a cascading select into the filter object
+ * sent with its options request (#3).
+ *
+ * A dependent field's options depend on a parent field's value — "provider teams
+ * for *this* team", "cities in *this* state". This hook watches the parent fields
+ * and returns their current values, which `OptionSelector` forwards to the options
+ * API as `dependencyFilters`.
+ *
+ * Two properties matter and are easy to get wrong:
+ *
+ * 1. **It must re-derive when a parent changes.** Parents start empty, so a value
+ *    captured once at mount is always `undefined`; the options request would then go
+ *    out with no parent filter, indistinguishable on the wire from a form where
+ *    nothing was selected. `Form.useWatch` returns a fresh array on every render and
+ *    so cannot be a memo dependency directly — the watched values are serialized
+ *    into a key that changes only on a real change.
+ *
+ * 2. **Empty parents are omitted, not sent as blanks.** Returning `undefined`
+ *    instead of `{ teamId: '' }` lets the backend tell "not chosen yet" from
+ *    "chosen as empty" and skip work (and, for API-backed options, upstream calls)
+ *    until the form is actually ready.
+ *
+ * `watchedDeps` is returned alongside so callers can clear a stale child selection
+ * when a parent changes, without setting up a second watch.
+ *
+ * @param dependsOn - parent field name, or names, this field depends on
+ * @param form - the antd form instance the fields live in
+ */
+export function useDependencyFilters(
+  dependsOn: string | string[] | undefined,
+  form: FormInstance | undefined
+): DependencyFiltersResult {
+  const watchedDeps = Form.useWatch(
+    dependsOn
+      ? (values: Record<string, unknown>) => {
+        const deps = Array.isArray(dependsOn) ? dependsOn : [ dependsOn ];
+        return deps.map(dep => values?.[ dep ]);
+      }
+      : () => null,
+    form
+  );
+
+  // Stable identity for the watched values, so the memo below recomputes on a real
+  // change but not on every unrelated re-render.
+  const watchedDepsKey = React.useMemo(
+    () => JSON.stringify(watchedDeps ?? null),
+    [ watchedDeps ]
+  );
+
+  const dependencyFilters = React.useMemo(() => {
+    if (!dependsOn || !form) return undefined;
+
+    const deps = Array.isArray(dependsOn) ? dependsOn : [ dependsOn ];
+    const filters: Record<string, unknown> = {};
+    let hasValue = false;
+
+    for (const dep of deps) {
+      const value = form.getFieldValue(dep);
+      if (value !== undefined && value !== null && value !== '') {
+        filters[ dep ] = value;
+        hasValue = true;
+      }
+    }
+
+    return hasValue ? filters : undefined;
+    // `watchedDepsKey` is the change signal; values are read back from the form so
+    // nested/array shapes come through exactly as the form holds them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ dependsOn, form, watchedDepsKey ]);
+
+  return { dependencyFilters, watchedDeps };
+}

--- a/src/core/types/field-config.ts
+++ b/src/core/types/field-config.ts
@@ -53,6 +53,16 @@ export type Template = string | ITemplateConfig;
 export interface IOptions {
   label: string;
   value: string | number;
+  /**
+   * Thumbnail shown beside the label in select, multi-select and radio fields.
+   *
+   * For choices identified visually — a team by its crest, a product by its photo —
+   * the image is what the user actually recognises, and a URL printed in the label
+   * text is no substitute. `label` stays the option's plain-text identity: it is
+   * what search filters against and what assistive technology announces, so it must
+   * remain meaningful on its own.
+   */
+  image?: string;
 }
 
 /**


### PR DESCRIPTION
Two changes to form option fields, in separate commits.

## 1. `dependsOn` cascading selects never sent the parent value

A dependent select carries its parent's value to the options API through
`dependencyFilters`. That derivation was memoized on `[dependsOn, form]` — both
stable for the component's lifetime — so it ran **once at mount**, when every parent
field is still empty, and never again. The `Form.useWatch` directly below it
re-rendered the field as its comment intended, but a re-render does not recompute a
`useMemo` whose dependencies have not changed.

So the options request went out with no parent filter at all. On the wire that is
indistinguishable from a form where nothing had been selected:

```
POST /admin/system/integration-setup/provider-teams
{"count":25,"search":"fife"}          ← no teamId, though a team was selected
```

This affected every consumer of `dependsOn`, not one form.

**Fix:** extracted the derivation into `useDependencyFilters`, keyed on a serialized
snapshot of the watched parent values. It recomputes on a real change, and keeps one
object identity across renders that change nothing — the filter object feeds a
react-query key, so a fresh object per render would refetch the options forever.

13 tests drive a real antd Form: the derivation itself, multi-parent `dependsOn`,
clearing a parent, empty-string handling, identity stability, and non-string values.
**Six of them fail against the previous memo dependencies** — verified by reverting
the deps and re-running.

## 2. Optional thumbnail on option rows

Some choices are recognised visually rather than by name — a team by its crest, a
product by its photo. An option could only carry text, so a config needing the
picture had to paste an image URL into the label and leave the user to open it in
another tab.

`IOptions` gains an optional `image`. When any option in a field carries one, the
dropdown rows, the radio list and the chosen value render it beside the label. When
none do, antd's default rendering is used untouched — `optionRender`/`labelRender`
are only attached when there is actually an image to show.

`label` stays the option's text identity: search filters against it and assistive
technology announces it, so the image is marked decorative (`alt=""`,
`aria-hidden`) and adds no duplicate announcement. An option without an image inside
a field that has them renders a same-size spacer, so rows stay aligned.

8 tests cover radio, select (querying the portal dropdown), multi-select, the
chosen-value display, the mixed with/without-image case, and that a field with no
images renders no image markup at all.

## Verification

- `npm run build` — passes (CI builds and commits `dist`, so `dist` is deliberately
  not in this PR)
- `npx tsc --noEmit` — no new errors. Four pre-existing errors in
  `src/table/hooks/useListExport.ts` remain untouched; they are unrelated to this
  change and left for their own PR.
- `npm test -- src/core/forms/FormField` — 21 tests, all passing
- `npm run test:all` — identical before and after: 428 passed, 3 failed, 12 suites
  failing to run. Those failures are pre-existing on `develop` (`import.meta` under
  ts-jest, plus the `useListExport` types above) and are not affected here. Note the
  `test:all` pattern list does not cover `core/forms/**/__tests__`, so the new tests
  run under plain `npm test`.

## Scope

Touches only `FormField.tsx`, `OptionSelector.tsx`, `IOptions` in
`core/types/field-config.ts`, and the two new test files. No behaviour change for
fields that use neither `dependsOn` nor `image`.
